### PR TITLE
Fix scripts

### DIFF
--- a/elastic-db-tools/src/main/java/com/microsoft/azure/elasticdb/shard/utils/SqlUtils.java
+++ b/elastic-db-tools/src/main/java/com/microsoft/azure/elasticdb/shard/utils/SqlUtils.java
@@ -296,7 +296,7 @@ public final class SqlUtils {
                     JarEntry e = jarEntries.nextElement();
                     String filePath = e.getName();
                     String name = filePath.substring(filePath.lastIndexOf("/") + 1);
-                    if (name.contains(prefix) && name.toLowerCase().endsWith(".sql")) {
+                    if (name.startsWith(prefix) && name.toLowerCase().endsWith(".sql")) {
                         fileNameList.add(name);
                     }                   
                 }

--- a/elastic-db-tools/src/main/java/com/microsoft/azure/elasticdb/shard/utils/SqlUtils.java
+++ b/elastic-db-tools/src/main/java/com/microsoft/azure/elasticdb/shard/utils/SqlUtils.java
@@ -295,7 +295,7 @@ public final class SqlUtils {
                 while (jarEntries.hasMoreElements()) {
                     JarEntry e = jarEntries.nextElement();
                     String name = e.getName();
-                    if (name.startsWith(prefix) && name.toLowerCase().endsWith(".sql")) {
+                    if (name.contains(prefix) && name.toLowerCase().endsWith(".sql")) {
                         fileNameList.add(name);
                     }                   
                 }

--- a/elastic-db-tools/src/main/java/com/microsoft/azure/elasticdb/shard/utils/SqlUtils.java
+++ b/elastic-db-tools/src/main/java/com/microsoft/azure/elasticdb/shard/utils/SqlUtils.java
@@ -294,7 +294,8 @@ public final class SqlUtils {
                 final Enumeration<JarEntry> jarEntries = jar.entries();
                 while (jarEntries.hasMoreElements()) {
                     JarEntry e = jarEntries.nextElement();
-                    String name = e.getName();
+                    String filePath = e.getName();
+                    String name = filePath.substring(filePath.lastIndexOf("/") + 1);
                     if (name.contains(prefix) && name.toLowerCase().endsWith(".sql")) {
                         fileNameList.add(name);
                     }                   


### PR DESCRIPTION
there is a bug that causes upgrading the shard map schema to fail because the sql scripts needed aren't discovered correctly.

when `com.microsoft.azure.elasticdb.shard.utils.SqlUtils#parseUpgradeScripts(boolean)` is called, it iterates through the JAR file and retrieves files under the script folder. when the files are processed, JarEntry.getName() returns the "full path + filename", and the check for "name.startsWith(prefix)" fails.

to fix this, we can simply strip off all paths before the file name and process it correctly.